### PR TITLE
Fix programme instantly exiting when input is piped in

### DIFF
--- a/dekryptize.c
+++ b/dekryptize.c
@@ -83,6 +83,7 @@ int main(int argc, char **argv)
 	int set[MAXRNDSET];
 	
 	FILE *f = stdin;
+	FILE *tty = fopen("/dev/tty", "r");
 	int status = 0;
 	char lin[256];
 
@@ -96,9 +97,15 @@ int main(int argc, char **argv)
 	srand(time(NULL));
 
 	setlocale(LC_ALL, "");
-
-	if (initscr() == NULL)
-		return 1;
+	if (f==stdin){
+		char* term_type = getenv("TERM");
+		SCREEN* out_screen = newterm(term_type, stdout, tty);
+		set_term(out_screen);
+	} else{
+		initscr();
+	}
+	// if (initscr() == NULL)
+	// 	return 1;
 	cbreak();
 	noecho();
 	nodelay(stdscr, TRUE);
@@ -184,7 +191,7 @@ int main(int argc, char **argv)
 	done = 0;
 	b = 0;
 	while (done < rndset) {
-		if (wgetch(stdscr) != ERR){
+		if (getch() != ERR){
 				status = -1;
 				break;
 		}

--- a/dekryptize.c
+++ b/dekryptize.c
@@ -9,6 +9,7 @@
 #include <locale.h>
 #include <ctype.h>
 #include <time.h>
+#include <unistd.h>
 
 #define MAXRNDSET 200
 
@@ -101,7 +102,6 @@ int main(int argc, char **argv)
 	cbreak();
 	noecho();
 	nodelay(stdscr, TRUE);
-
 	nonl();
 	intrflush(stdscr, FALSE);
 	keypad(stdscr, TRUE);
@@ -140,9 +140,9 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (f != stdin)
+	if (f != stdin){
 		fclose(f);
-
+	}
 	// randomize initial state
 
 	for (i = 0; i < 6; i++) {
@@ -183,8 +183,11 @@ int main(int argc, char **argv)
 	
 	done = 0;
 	b = 0;
-	while (getch() == ERR && done < rndset) {
-	
+	while (done < rndset) {
+		if (wgetch(stdscr) != ERR){
+				status = -1;
+				break;
+		}
 		// animate the set
 	
 		for (i = 0; i < rndset; i++) {
@@ -236,16 +239,20 @@ int main(int argc, char **argv)
 		if (b == 20)
 			b = 0;
 	}
-
 	standout();
-	mvprintw(rows, cols / 2 - 11, " [MESSAGE DECRYPTED] ");
+	if (status != 0){
+		mvprintw(rows, cols / 2 - 24, " [DECRYPTION TERMINATED, PRESS ANY KEY TO EXIT] ");
+	} else {
+		mvprintw(rows, cols / 2 - 11, " [MESSAGE DECRYPTED] ");
+	}
 	standend();
-	refresh();
-
-	nodelay(stdscr, FALSE);
-
-	getch();
-
+	refresh();	
+	// nodelay(stdscr, FALSE);
+	while(1){
+		if (getch() != ERR){
+			break;
+		}
+	}
 	// cleanup
 	endwin();
 	if (buf != NULL)


### PR DESCRIPTION
The programme would quit instantly if it registered a keypress, or if used with input piped from another programme. Setting the screen to read from /dev/tty fixes that, allowing things like 
![testy](https://cloud.githubusercontent.com/assets/3513885/21371432/41ee3230-c709-11e6-9ea9-1de31769cbba.gif)
